### PR TITLE
Moving to use arxiv directly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "pandas == 2.0.0",
     "httpx == 0.24.0",
     "pyarrow == 11.0.0",
-    "click == 8.1.3"
+    "click == 8.1.3",
+    "arxiv == 1.4.5"
     ]
 
 [build-system]


### PR DESCRIPTION
arxiv-sanity is proving to be not stable enough. This makes the bot use directly arxiv