### PR TITLE
Handle new X API limits

### DIFF
--- a/.github/workflows/run-arxiv-sanity-bot.yml
+++ b/.github/workflows/run-arxiv-sanity-bot.yml
@@ -2,7 +2,7 @@ name: Run Arxiv Sanity Bot
 
 on:
   schedule:
-    - cron: "15 1,13 * * *"
+    - cron: "0 15 * * *"
   workflow_dispatch:
     inputs:
       window_start:

--- a/arxiv_sanity_bot/cli/arxiv_sanity_bot.py
+++ b/arxiv_sanity_bot/cli/arxiv_sanity_bot.py
@@ -84,7 +84,7 @@ def send_tweets(n_retrieved: int, summaries: list[dict[str, Any]], doc_store: Do
         logger.critical("Could not generate summary tweet")
         raise FatalError("Could not generate summary tweet")
 
-    _ = tweet_sender(summary_tweet, auth=oauth)
+    summary_tweet_url, summary_tweet_id = tweet_sender(summary_tweet, auth=oauth)
 
     for s in summaries[::-1]:
         # Introduce a random delay between the tweets to avoid triggering
@@ -94,7 +94,7 @@ def send_tweets(n_retrieved: int, summaries: list[dict[str, Any]], doc_store: Do
         time.sleep(delay)
 
         this_url, this_tweet_id = tweet_sender(
-            s["tweet"], auth=oauth, img_path=s["image"]
+            s["tweet"], auth=oauth, img_path=s["image"], in_reply_to_tweet_id=summary_tweet_id
         )
 
         if this_url is not None:

--- a/arxiv_sanity_bot/config.py
+++ b/arxiv_sanity_bot/config.py
@@ -4,7 +4,7 @@ from zoneinfo import ZoneInfo
 # Papers under this score will not be posted
 # NOTE: Score system changed - now 1-2 points (ranked sources) instead of Altmetric 0-100+
 SCORE_THRESHOLD = 1
-MAX_NUM_PAPERS = 10
+MAX_NUM_PAPERS = 7
 
 # Source for the abstracts
 # Options: "arxiv", "arxiv-sanity", "ranked"


### PR DESCRIPTION
Handle new X API limits. Since now we're generating two posts per paper, we need to only run once a day to accommodate the new 17 posts/day limit on the X free tier.